### PR TITLE
Remove collapsing blocks

### DIFF
--- a/ExerciseRunner.elm
+++ b/ExerciseRunner.elm
@@ -133,11 +133,6 @@ type alias Example =
     }
 
 
-isFinished : Example -> Bool
-isFinished example =
-    List.all (\(TestCase _ isCorrect _ _) -> isCorrect) example.testCases
-
-
 viewExample : Example -> Html Never
 viewExample { name, testCases } =
     let
@@ -213,29 +208,11 @@ functionExample3 name function testCases =
         testCases
 
 
-viewSection : (a -> Html msg) -> String -> List a -> Html msg
-viewSection view title content =
-    Html.div []
-        [ Html.h2 [] [ Html.text title ]
-        , content
-            |> List.map view
-            |> Html.div []
-        ]
-
-
 viewExampleSection : String -> List Example -> Html Never
 viewExampleSection title examples =
-    if List.all isFinished examples then
-        Html.span
-            [ Html.Attributes.class "title-font"
-            , Html.Attributes.style "background-color" Style.successColor
-            , Html.Attributes.style "padding" "4px"
-            , Html.Attributes.style "margin" "4px"
-            ]
-            [ Html.text Style.successEmoji
-            , Html.text " "
-            , Html.text title
-            ]
-
-    else
-        viewSection viewExample title examples
+    Html.div []
+        [ Html.h2 [] [ Html.text title ]
+        , examples
+            |> List.map viewExample
+            |> Html.div []
+        ]

--- a/ExerciseRunner.elm
+++ b/ExerciseRunner.elm
@@ -15,8 +15,7 @@ module ExerciseRunner exposing
 import Debug
 import Html exposing (Html)
 import Html.Attributes
-import String
-import Style exposing (..)
+import Style
 
 
 outputLabel : String -> Html msg
@@ -65,13 +64,13 @@ viewAssertion isCorrect call actual expected =
     if isCorrect then
         Html.div
             [ Html.Attributes.style "margin-left" "32px"
-            , Html.Attributes.style "background-color" successColor
+            , Html.Attributes.style "background-color" Style.successColor
             ]
             [ Html.span
                 [ Html.Attributes.style "padding" "4px"
                 , Html.Attributes.style "margin" "8px"
                 ]
-                [ Html.text successEmoji ]
+                [ Html.text Style.successEmoji ]
             , inlineCode call
             , Html.text " == "
             , Html.text actual
@@ -83,13 +82,13 @@ viewAssertion isCorrect call actual expected =
             ]
             [ outputLabel "Your implementation:"
             , Html.div
-                [ Html.Attributes.style "background-color" keepWorkingColor
+                [ Html.Attributes.style "background-color" Style.keepWorkingColor
                 ]
                 [ Html.span
                     [ Html.Attributes.style "padding" "4px"
                     , Html.Attributes.style "margin" "8px"
                     ]
-                    [ Html.text keepWorkingEmoji ]
+                    [ Html.text Style.keepWorkingEmoji ]
                 , inlineCode call
                 , Html.text " == "
                 , Html.text actual
@@ -103,7 +102,7 @@ viewAssertion isCorrect call actual expected =
                     , Html.Attributes.style "margin" "8px"
                     , Html.Attributes.style "opacity" "0"
                     ]
-                    [ Html.text keepWorkingEmoji ]
+                    [ Html.text Style.keepWorkingEmoji ]
                 , inlineCode call
                 , Html.text " == "
                 , Html.text expected
@@ -233,7 +232,7 @@ viewExampleSection title examples =
             , Html.Attributes.style "padding" "4px"
             , Html.Attributes.style "margin" "4px"
             ]
-            [ Html.text successEmoji
+            [ Html.text Style.successEmoji
             , Html.text " "
             , Html.text title
             ]

--- a/Main.elm
+++ b/Main.elm
@@ -1,9 +1,8 @@
 module Main exposing (main)
 
-import ExerciseRunner exposing (..)
+import ExerciseRunner
 import Html exposing (Html)
 import Html.Attributes
-import String
 
 
 
@@ -152,20 +151,20 @@ pigLatin word =
 --
 
 
-examples : List ( String, List Example )
+examples : List ( String, List ExerciseRunner.Example )
 examples =
     [ ( "Strings"
-      , [ functionExample1 "sayHello"
+      , [ ExerciseRunner.functionExample1 "sayHello"
             sayHello
             [ ( "Jasmine", "Hello, Jasmine" )
             , ( "Jean", "Hello, Jean" )
             ]
-        , functionExample3 "formatPhoneNumber"
+        , ExerciseRunner.functionExample3 "formatPhoneNumber"
             formatPhoneNumber
             [ ( ( "347", "489", "4608" ), "(347) 489-4608" )
             , ( ( "800", "555", "2368" ), "(800) 555-2368" )
             ]
-        , functionExample2 "initials"
+        , ExerciseRunner.functionExample2 "initials"
             initials
             [ ( ( "Ada", "Yonath" ), "AY" )
             , ( ( "Kimberlé", "Crenshaw" ), "KC" )
@@ -174,13 +173,13 @@ examples =
         ]
       )
     , ( "If Statements"
-      , [ functionExample1 "isGreaterThanTen"
+      , [ ExerciseRunner.functionExample1 "isGreaterThanTen"
             isGreaterThanTen
             [ ( 13, True )
             , ( 3, False )
             , ( 10, False )
             ]
-        , functionExample1 "howHotIsThePepper"
+        , ExerciseRunner.functionExample1 "howHotIsThePepper"
             howHotIsThePepper
             [ ( 2, "not hot" )
             , ( 100, "mild" )
@@ -190,17 +189,17 @@ examples =
         ]
       )
     , ( "Lists"
-      , [ functionExample1 "reverseTheList"
+      , [ ExerciseRunner.functionExample1 "reverseTheList"
             reverseTheList
             [ ( [ 7, 0, 1, 4, 9 ], [ 9, 4, 1, 0, 7 ] )
             , ( [ 99, -1 ], [ -1, 99 ] )
             ]
-        , functionExample1 "addOne"
+        , ExerciseRunner.functionExample1 "addOne"
             addOne
             [ ( [ 7, 0, 1, 4, 9 ], [ 8, 1, 2, 5, 10 ] )
             , ( [ 99, -1 ], [ 100, 0 ] )
             ]
-        , functionExample1 "removeOs"
+        , ExerciseRunner.functionExample1 "removeOs"
             removeOs
             [ ( [ "Jessie", "Anibus", "Osirus" ], [ "Jessie", "Anibus" ] )
             , ( [ "Apple", "Banana" ], [ "Apple", "Banana" ] )
@@ -209,28 +208,28 @@ examples =
         ]
       )
     , ( "Records"
-      , [ functionExample1 "newborn"
+      , [ ExerciseRunner.functionExample1 "newborn"
             newborn
             [ ( "Jenny", { name = "Jenny", age = 0 } )
             , ( "Abey", { name = "Abey", age = 0 } )
             ]
-        , functionExample2 "ageDifference"
+        , ExerciseRunner.functionExample2 "ageDifference"
             ageDifference
             [ ( ( { name = "Nicole", age = 40 }, { name = "Angel", age = 30 } ), 10 )
             , ( ( { name = "Igor", age = 18 }, { name = "Alexei", age = 23 } ), 5 )
             ]
-        , functionExample2 "nameChange"
+        , ExerciseRunner.functionExample2 "nameChange"
             nameChange
             [ ( ( "Mr. T", { name = "Laurence", age = 34 } ), { name = "Mr. T", age = 34 } )
             , ( ( "Demi", { name = "Demetria", age = 17 } ), { name = "Demi", age = 17 } )
             , ( ( "Ƭ̵̬̊", { name = "Prince", age = 35 } ), { name = "Ƭ̵̬̊", age = 35 } )
             ]
-        , functionExample1 "getOlder"
+        , ExerciseRunner.functionExample1 "getOlder"
             getOlder
             [ ( { name = "Jenny", age = 0 }, { name = "Jenny", age = 1 } )
             , ( { name = "Igor", age = 18 }, { name = "Igor", age = 19 } )
             ]
-        , functionExample1 "combinedYears"
+        , ExerciseRunner.functionExample1 "combinedYears"
             combinedYears
             [ ( [ { name = "Ruth Bader Ginsburg", age = 83 }
                 , { name = "Gloria Allred", age = 75 }
@@ -254,10 +253,10 @@ examples =
     ]
 
 
-bonusExamples : List ( String, List Example )
+bonusExamples : List ( String, List ExerciseRunner.Example )
 bonusExamples =
     [ ( "Tuples"
-      , [ functionExample1 "signAndMagnitude"
+      , [ ExerciseRunner.functionExample1 "signAndMagnitude"
             signAndMagnitude
             [ ( -7, ( "-", 7 ) )
             , ( 3, ( "+", 3 ) )
@@ -267,7 +266,7 @@ bonusExamples =
         ]
       )
     , ( "Strings (cont.)"
-      , [ functionExample1 "pigLatin"
+      , [ ExerciseRunner.functionExample1 "pigLatin"
             pigLatin
             [ ( "Pig", "Ig-pay" )
             , ( "Latin", "Atin-lay" )
@@ -287,12 +286,12 @@ main : Html Never
 main =
     Html.div
         [ Html.Attributes.style "padding" "20px" ]
-        [ fontStyles
+        [ ExerciseRunner.fontStyles
         , examples
-            |> List.map (\( title, x ) -> viewExampleSection title x)
+            |> List.map (\( title, x ) -> ExerciseRunner.viewExampleSection title x)
             |> Html.div []
         , Html.h1 [] [ Html.text "Bonus Sections" ]
         , bonusExamples
-            |> List.map (\( title, x ) -> viewExampleSection title x)
+            |> List.map (\( title, x ) -> ExerciseRunner.viewExampleSection title x)
             |> Html.div []
         ]

--- a/Style.elm
+++ b/Style.elm
@@ -5,21 +5,26 @@ module Style exposing (expectedColor, keepWorkingColor, keepWorkingEmoji, succes
 --
 
 
+successEmoji : String
 successEmoji =
     "💖"
 
 
+successColor : String
 successColor =
     "rgb(46, 204, 64)"
 
 
+keepWorkingEmoji : String
 keepWorkingEmoji =
     "🚧"
 
 
+keepWorkingColor : String
 keepWorkingColor =
     "rgb(255, 220, 0)"
 
 
+expectedColor : String
 expectedColor =
     "rgb(170, 170, 170)"


### PR DESCRIPTION
I've witnessed this quite a few times when a student is confused when the whole block of tests is collapsed. They feel that their work is lost, it doesn't feel rewarding at all. 

![collapse](https://user-images.githubusercontent.com/43472/87230741-27599a00-c3b2-11ea-9513-8b6c0145228a.gif)

I don't know what the best solution would be, but maybe removing collapsible blocks (done in this PR) is still an improvement. The browser keeps the scroll when the page is refreshed, so there is no big risk in losing the track of progress.

![no-collapse](https://user-images.githubusercontent.com/43472/87230779-4f48fd80-c3b2-11ea-8e46-a98d225e1c90.gif)


